### PR TITLE
Switch build dependency from libtiff4-dev to libtiff5-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: graphics
 Priority: optional
 Maintainer: Canon Inc. <sup-debian@list.canon.co.jp>
 Build-Depends: debhelper (>= 4.0.0), libcupsys2-dev | libcups2-dev,
-               libxml2-dev, libtiff4-dev, automake, autoconf,
+               libxml2-dev, libtiff-dev, automake, autoconf,
                autotools-dev, libtool, libglib2.0-dev, libgtk2.0-dev,
                libpopt-dev, libusb-1.0-0-dev
 Standards-Version: 3.7.2


### PR DESCRIPTION
CUPS 2.2 depends on libtiff5, so trying to keep libtiff4 as a build-dep
here causes a conflict and breaks the build innecessarily, as this
package should build and work just fine with libtiff5 too.

https://phabricator.endlessm.com/T15707