### PR TITLE
debian: do not install UI utilities

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,4 @@
 debian/utils/maintenance.desktop		/usr/share/applications/
-debian/utils/cngpijmon.desktop			/usr/share/applications/
+#debian/utils/cngpijmon.desktop			/usr/share/applications/
 debian/utils/canon-maintenance			/usr/bin/
-debian/utils/canon-ijmon				/usr/bin/
+#debian/utils/canon-ijmon				/usr/bin/

--- a/debian/rules
+++ b/debian/rules
@@ -178,7 +178,8 @@ PRINTER_PKG_PROGRAM+=ppd
 PRINTER_PKG_PROGRAM+=cnijfilter
 PRINTER_PKG_PROGRAM+=printui
 PRINTER_PKG_PROGRAM+=lgmon
-PRINTER_PKG_PROGRAM+=cngpijmon
+# Endless: we do not install the UI programs
+#PRINTER_PKG_PROGRAM+=cngpijmon
 
 PRINTER_PKG_PPD+=cnijfilter-i550-2.20-pixus550i-32
 PRINTER_PKG_PPD+=cnijfilter-i850-2.20-pixus850i-32

--- a/debian/skel/install.skel
+++ b/debian/skel/install.skel
@@ -1,4 +1,4 @@
 debian/utils/maintenance.desktop		/usr/share/applications/
-debian/utils/cngpijmon.desktop			/usr/share/applications/
+#debian/utils/cngpijmon.desktop			/usr/share/applications/
 debian/utils/canon-maintenance			/usr/bin/
-debian/utils/canon-ijmon				/usr/bin/
+#debian/utils/canon-ijmon				/usr/bin/


### PR DESCRIPTION
This way we will be able to remove a GTK2 dependency.

https://phabricator.endlessm.com/T21074